### PR TITLE
Fix Chart.js version

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,7 +28,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.32.0/css/theme.ice.min.css" integrity="sha512-KNtKlElwWdbTLSi3E9U95sSnTqhnt12n7lEn1ap3sPB9oiFcIrKTUprR5E9KU2BjmqsRQWcEG5lRHWfvUIlHHA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
     <!-- Include Chart.js -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.min.js" integrity="sha512-L0Shl7nXXzIlBSUUPpxrokqq4ojqgZFQczTYlGjzONGTDAcLremjwaWv5A+EDLnxhQzY5xUZPWLOLqYRkY0Cbw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
     <link rel="stylesheet" href="/assets/css/global.css" />
     <script src="/assets/js/global.js"></script>


### PR DESCRIPTION
## Summary
- use Chart.js v3.9.1 instead of ES module build

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: the command requires filenames)*

------
https://chatgpt.com/codex/tasks/task_e_684011800254832da263afda80a2258b