### PR TITLE
Add date range buttons for charts

### DIFF
--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -84,3 +84,11 @@ img{
     max-width: 100%;
 }
 
+.chart-range-buttons{
+    margin-top: 0.5rem;
+}
+
+.chart-range-buttons button{
+    margin-right: 0.25rem;
+}
+


### PR DESCRIPTION
## Summary
- detect if chart labels are dates
- add helper to filter chart data by start date
- render buttons below charts to filter the last 5yr, 1yr, ytd, 1mo or show all
- style new button container

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6840c0e159a0832da7ad425e3c64d5e5