### PR TITLE
Enable descending sort on data tables

### DIFF
--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -75,6 +75,7 @@ function SourceTabler($container){
                 $container.html(table);
                 //$(table).tablesorter();
                 table = new DataTable('#data-table table', {
+                    order: [[0, 'desc']],
                     columnDefs: [
                         {
                             targets: '_all',


### PR DESCRIPTION
## Summary
- tweak table initialization to sort descending by the first column

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6840c497943c832db092b08363c21f28