### PR TITLE
Fix update errors

### DIFF
--- a/data/catalog.csv
+++ b/data/catalog.csv
@@ -14,8 +14,8 @@ news-europe,nyt,rss,news-europe-nyt,https://rss.nytimes.com/services/xml/rss/nyt
 news-asia,nyt,rss,news-asia-nyt,https://rss.nytimes.com/services/xml/rss/nyt/AsiaPacific.xml,,daily,,Asia News from the New York Times,https://www.nytimes.com
 news-americas,nyt,rss,news-americas-nyt,https://rss.nytimes.com/services/xml/rss/nyt/Americas.xml,,daily,,Americas' News from the New York Times,https://www.nytimes.com
 news-middle-east,nyt,rss,news-middle-east-nyt,https://rss.nytimes.com/services/xml/rss/nyt/MiddleEast.xml,,daily,,Middle East News from the New York Times,https://www.nytimes.com
-news-business,nyt,rss,news-business-nyt,https://rss.nytimes.com/services/xml/rss/nyt/Business.xml,daily,,Business News from the New York Times,https://www.nytimes.com
-news-economy,nyt,rss,news-economy-nyt,https://rss.nytimes.com/services/xml/rss/nyt/Economy.xml,daily,,Economic News from the New York Times,https://www.nytimes.com
+news-business,nyt,rss,news-business-nyt,https://rss.nytimes.com/services/xml/rss/nyt/Business.xml,,daily,,Business News from the New York Times,https://www.nytimes.com
+news-economy,nyt,rss,news-economy-nyt,https://rss.nytimes.com/services/xml/rss/nyt/Economy.xml,,daily,,Economic News from the New York Times,https://www.nytimes.com
 news-us-politics,nyt,rss,news-us-politics-nyt,https://rss.nytimes.com/services/xml/rss/nyt/Politics.xml,,daily,,US Politics News from the New York Times,https://www.nytimes.com
 news-world,wsj,rss,news-world-wsj,https://feeds.content.dowjones.io/public/rss/RSSWorldNews,,daily,,World News from the Wall Street Journal,https://www.wsj.com
 news-us,wsj,rss,news-us-wsj,https://feeds.content.dowjones.io/public/rss/RSSUSNews,,daily,,US News from the Wall Street Journal,https://www.wsj.com

--- a/data/update.ipynb
+++ b/data/update.ipynb
@@ -217,6 +217,7 @@
     "\n",
     "for row in cat:\n",
     "    folder = BASE_DIR / row['category'] / row['source'] / row['folder']\n",
+    "    folder.mkdir(parents=True, exist_ok=True)\n",
     "    filetype = row['filetype'].strip().lstrip('.')\n",
     "    output_ext = 'json' if filetype.lower() in ('rss', 'xml') else filetype\n",
     "    desc = row['description'].strip()\n",


### PR DESCRIPTION
## Summary
- fill in missing `api_key` cells for NYT business and economy feeds
- create output folders when generating index files in `update.ipynb`

## Testing
- `python3 -m json.tool data/update.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_68411801eb9c832d8fbee7a976dbb3e3