### PR TITLE
Add headlines aggregation

### DIFF
--- a/analysis/headlines/update_headlines.ipynb
+++ b/analysis/headlines/update_headlines.ipynb
@@ -1,0 +1,108 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Update Headlines"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import csv\n",
+    "import json\n",
+    "import xml.etree.ElementTree as ET\n",
+    "from datetime import datetime\n",
+    "import shutil\n",
+    "\n",
+    "DATA_DIR = Path('data').resolve()\n",
+    "HEADLINES_DIR = Path('analysis/headlines').resolve()\n",
+    "HEADLINES_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "def parse_feed(path: Path):\n",
+    "    entries = []\n",
+    "    if path.suffix == '.json':\n",
+    "        with open(path, 'r', encoding='utf-8') as f:\n",
+    "            data = json.load(f)\n",
+    "        for item in data.get('entries', []):\n",
+    "            title = item.get('title')\n",
+    "            link = item.get('link')\n",
+    "            if title and link:\n",
+    "                entries.append((title.strip(), link.strip()))\n",
+    "    else:\n",
+    "        try:\n",
+    "            tree = ET.parse(path)\n",
+    "            root = tree.getroot()\n",
+    "        except ET.ParseError:\n",
+    "            return entries\n",
+    "        for item in root.iter():\n",
+    "            if item.tag.lower().endswith(('item', 'entry')):\n",
+    "                title = None\n",
+    "                link = None\n",
+    "                for child in item:\n",
+    "                    if child.tag.lower().endswith('title'):\n",
+    "                        title = (child.text or '').strip()\n",
+    "                    if child.tag.lower().endswith('link'):\n",
+    "                        link = (child.text or '').strip() or child.attrib.get('href')\n",
+    "                if title and link:\n",
+    "                    entries.append((title, link))\n",
+    "    return entries\n",
+    "\n",
+    "def collect_headlines():\n",
+    "    all_entries = []\n",
+    "    for source in DATA_DIR.iterdir():\n",
+    "        if source.is_dir() and source.name.startswith('news'):\n",
+    "            candidates = [p for p in source.rglob('latest.*') if p.suffix in {'.json', '.rss', '.xml'}]\n",
+    "            if not candidates:\n",
+    "                candidates = [p for p in source.rglob('*') if p.suffix in {'.json', '.rss', '.xml'}]\n",
+    "            if not candidates:\n",
+    "                continue\n",
+    "            latest_file = max(candidates, key=lambda p: p.stat().st_mtime)\n",
+    "            all_entries.extend(parse_feed(latest_file))\n",
+    "    return all_entries\n",
+    "\n",
+    "def update_headlines():\n",
+    "    timestamp = datetime.utcnow().strftime('%Y-%m-%d-%H-00')\n",
+    "    hourly_file = HEADLINES_DIR / f'{timestamp}.csv'\n",
+    "    if hourly_file.exists():\n",
+    "        print(f'{hourly_file.name} already exists. Skipping update.')\n",
+    "        return\n",
+    "    entries = collect_headlines()\n",
+    "    with open(hourly_file, 'w', newline='', encoding='utf-8') as f:\n",
+    "        writer = csv.writer(f)\n",
+    "        writer.writerow(['title', 'link'])\n",
+    "        writer.writerows(entries)\n",
+    "    latest_file = HEADLINES_DIR / 'latest.csv'\n",
+    "    shutil.copy(hourly_file, latest_file)\n",
+    "    print(f'Wrote {hourly_file} and updated latest.csv')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "update_headlines()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add Jupyter notebook to gather latest headlines from all news data sources
- remove generated CSVs from version control

## Testing
- `python3 - <<'PY'
import json
ip=json.load(open('analysis/headlines/update_headlines.ipynb'))
code='\n'.join(''.join(c['source']) if isinstance(c['source'],list) else c['source'] for c in ip['cells'] if c['cell_type']=='code')
exec(compile(code,'<nb>','exec'),{})
PY`
- `python3 - <<'PY'
import json,py_compile,sys,tempfile,os
ip=json.load(open('analysis/headlines/update_headlines.ipynb'))
code='\n'.join(''.join(c['source']) if isinstance(c['source'],list) else c['source'] for c in ip['cells'] if c['cell_type']=='code')
fd,path=tempfile.mkstemp(suffix='.py');os.write(fd,code.encode());os.close(fd)
py_compile.compile(path,doraise=True);os.remove(path);print('compile ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68411eae2a10832d852ac1ebd19b30c3