### PR TITLE
Add news topics analysis notebook

### DIFF
--- a/analysis/news-topics/analyze_headlines.ipynb
+++ b/analysis/news-topics/analyze_headlines.ipynb
@@ -1,0 +1,91 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Load latest headlines"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import pandas as pd\n",
+        "latest = pd.read_csv('../headlines/latest.csv')\n",
+        "latest.head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Calculate word frequencies"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import re\n",
+        "from collections import Counter\n",
+        "from datetime import datetime\n",
+        "\n",
+        "stop_words = {'the','of','at','a','an','and','or','to','in','on','for','with','as','is','are','be','from'}\n",
+        "words = re.findall(r'[A-Za-z]+', ' '.join(latest['title']).lower())\n",
+        "filtered = [w for w in words if w not in stop_words]\n",
+        "counts = Counter(filtered)\n",
+        "score_df = pd.DataFrame(counts.items(), columns=['word','score']).sort_values('score', ascending=False)\n",
+        "score_df.to_csv('scores.csv', index=False)\n",
+        "timestamp = datetime.utcnow().strftime('%Y-%m-%d-%H-%M-00')\n",
+        "score_df.to_csv(f'scores-{timestamp}.csv', index=False)\n",
+        "score_df.head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Rank headlines by score"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "word_scores = dict(score_df.values)\n",
+        "latest['score'] = latest['title'].apply(lambda t: sum(word_scores.get(w.lower(),0) for w in re.findall(r'[A-Za-z]+', t)))\n",
+        "ranked = latest.sort_values('score', ascending=False)\n",
+        "ranked.to_csv('rank.csv', index=False)\n",
+        "ranked.to_csv(f'rank-{timestamp}.csv', index=False)\n",
+        "ranked.head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Next steps"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- start a new `analysis/news-topics` project
- add a notebook to fetch headlines, score words, and rank headlines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841332b362c832d887896c7acfded6a