### PR TITLE
Improve news topics page with data tables

### DIFF
--- a/analysis/news-topics/index.md
+++ b/analysis/news-topics/index.md
@@ -4,21 +4,63 @@ title: Headline Topics
 date: 2025-06-05
 ---
 
-## Latest Headlines
+## Overview
 
-We start with the list of all headlines, sorted by publication date and deduplicated.
+This project analyzes the latest headlines to surface common themes. The notebook that generates these results runs in three steps:
 
-We count the instances of all the unique words in all the headlines and then use that to score all the headlines and sort them.
+1. **Load and deduplicate headlines**
+2. **Calculate word scores**
+3. **Rank the headlines**
 
-<div id="headline-table"></div>
+Each section below explains the step and presents its current output as an interactive table.
+
+### 1. Load and deduplicate headlines
+
+All stories are pulled from our [headlines collection](../headlines/), ordered by publication date and stripped of duplicate titles.
+
+<div id="step1-table"></div>
+
+### 2. Calculate word scores
+
+The headline text is tokenized and every unique word counted, ignoring the stop words listed in `exclude.txt`. The raw frequency of each word becomes its score.
+
+<div id="step2-table"></div>
+
+### 3. Rank the headlines
+
+For each headline we sum the scores of the words it contains and sort the list from highest to lowest.
+
+<div id="step3-table"></div>
+
 <script>
+function loadCsvTable(sel, csvPath){
+  fetch(csvPath)
+    .then(r => r.text())
+    .then(text => {
+      const rows = csvToObjects(text);
+      const table = ArrTabler(rows);
+      $(sel).html(table);
+      new DataTable(sel + ' table', {
+        order: [[0, 'desc']],
+        columnDefs: [
+          { targets: '_all', className: 'dt-head-left dt-body-left' }
+        ]
+      });
+    })
+    .catch(() => {
+      $(sel).text('Unable to load data.');
+    });
+}
+
 document.addEventListener('DOMContentLoaded', function(){
-  HeadlinesLister($('#headline-table'));
+  loadCsvTable('#step1-table', '../headlines/latest.csv');
+  loadCsvTable('#step2-table', './scores.csv');
+  loadCsvTable('#step3-table', './rank.csv');
 });
 </script>
 
 ## File Versions:
-{% assign csv_files = site.static_files | where:"extname", ".csv" | where_exp:"f","f.path contains 'analysis/headlines/'" | sort: 'name' | reverse %}
+{% assign csv_files = site.static_files | where:"extname", ".csv" | where_exp:"f","f.path contains 'analysis/news-topics/'" | sort: 'name' | reverse %}
 <ol>
   <li><a href="./latest.csv">Latest version</a></li>
   {% for file in csv_files %}


### PR DESCRIPTION
## Summary
- explain the workflow for ranking headline topics
- show data tables for the latest headlines, word scores and ranked headlines
- list CSV versions for the news-topics project

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68413fda6728832daad6189069c95c81