### PR TITLE
Add interactive catalog notebook

### DIFF
--- a/data/addToCatalog.ipynb
+++ b/data/addToCatalog.ipynb
@@ -1,0 +1,123 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Add Data Source to Catalog\n",
+    "This notebook guides you through adding a new data source to `catalog.csv`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Ensure required packages\n",
+    "import importlib, subprocess, sys\n",
+    "\n",
+    "def _ensure(pkg_name, import_name=None):\n",
+    "    try:\n",
+    "        importlib.import_module(import_name or pkg_name)\n",
+    "    except ModuleNotFoundError:\n",
+    "        subprocess.check_call([sys.executable, '-m', 'pip', 'install', pkg_name])\n",
+    "    finally:\n",
+    "        globals()[import_name or pkg_name] = importlib.import_module(import_name or pkg_name)\n",
+    "\n",
+    "for pkg in ('pandas','requests','feedparser'):\n",
+    "    _ensure(pkg)\n",
+    "print('Dependencies ready.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from pathlib import Path\n",
+    "import csv\n",
+    "import pandas as pd, requests, feedparser\n",
+    "\n",
+    "BASE_DIR = Path.cwd() if Path('catalog.csv').exists() else Path.cwd() / 'data'\n",
+    "catalog_path = BASE_DIR / 'catalog.csv'\n",
+    "cat = pd.read_csv(catalog_path)\n",
+    "\n",
+    "KEY_PHRASES = ['business','world news','economy','politics']\n",
+    "\n",
+    "def detect_filetype(url, resp):\n",
+    "    u = url.lower()\n",
+    "    if u.endswith('.rss') or u.endswith('.xml'):\n",
+    "        return 'rss'\n",
+    "    if u.endswith('.json'):\n",
+    "        return 'json'\n",
+    "    if u.endswith('.csv'):\n",
+    "        return 'csv'\n",
+    "    ct = resp.headers.get('content-type','').lower()\n",
+    "    if 'json' in ct:\n",
+    "        return 'json'\n",
+    "    if 'csv' in ct or 'text/plain' in ct:\n",
+    "        return 'csv'\n",
+    "    if 'xml' in ct or 'rss' in ct:\n",
+    "        return 'rss'\n",
+    "    return None\n",
+    "\n",
+    "while True:\n",
+    "    url = input('URL (blank to exit): ').strip()\n",
+    "    if not url:\n",
+    "        break\n",
+    "    try:\n",
+    "        resp = requests.get(url, timeout=15, headers={'User-Agent':'Mozilla/5.0'})\n",
+    "        resp.raise_for_status()\n",
+    "    except Exception as e:\n",
+    "        print('Error fetching:', e)\n",
+    "        continue\n",
+    "    ftype = detect_filetype(url, resp)\n",
+    "    if not ftype:\n",
+    "        print('Could not determine file type.')\n",
+    "        continue\n",
+    "    title = ''\n",
+    "    if ftype == 'rss':\n",
+    "        feed = feedparser.parse(resp.content)\n",
+    "        title = feed.feed.get('title','')\n",
+    "        text = ' '.join(' '.join(filter(None,[e.get('title',''), e.get('summary','')])) for e in feed.entries).lower()\n",
+    "        if any(p in text for p in KEY_PHRASES):\n",
+    "            print('Key phrase found in feed.')\n",
+    "    print('Detected type:', ftype)\n",
+    "    if title:\n",
+    "        print('Feed title:', title)\n",
+    "    row = {\n",
+    "        'category': input('Category: '),\n",
+    "        'source': input('Source: '),\n",
+    "        'filetype': ftype,\n",
+    "        'folder': input('Folder name: '),\n",
+    "        'url': url,\n",
+    "        'api_key': '',\n",
+    "        'cadence': input('Cadence (e.g., hourly): '),\n",
+    "        'last_fetched': '',\n",
+    "        'description': input('Description: '),\n",
+    "        'link': input('Link: ')\n",
+    "    }\n",
+    "    print('Proposed row:', row)\n",
+    "    if input('Add to catalog? [y/N] ').lower().startswith('y'):\n",
+    "        with open(catalog_path, 'a', newline='') as f:\n",
+    "            writer = csv.DictWriter(f, fieldnames=cat.columns)\n",
+    "            writer.writerow(row)\n",
+    "        cat = pd.read_csv(catalog_path)\n",
+    "        print('Row added.')\n",
+    "    else:\n",
+    "        print('Skipped.')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- create `data/addToCatalog.ipynb` to interactively add URLs to `catalog.csv`

## Testing
- `jq '.' data/addToCatalog.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_684505e42744832dbfde547a3b30fa77