### PR TITLE
Fix update notebook to sync latest data

### DIFF
--- a/data/update.ipynb
+++ b/data/update.ipynb
@@ -165,6 +165,8 @@
     "    latest_fp = folder / f'latest.{output_ext}'\n",
     "    dated_fp = folder / f\"{now:%Y-%m-%d-%H}.{output_ext}\" if cadence == \"hourly\" else folder / f\"{today:%Y-%m-%d}.{output_ext}\"\n",
     "    if dated_fp.exists():\n",
+    "        if (not latest_fp.exists()) or latest_fp.read_bytes() != dated_fp.read_bytes():\n",
+    "            shutil.copyfile(dated_fp, latest_fp)\n",
     "        cat.at[idx, 'last_fetched'] = now.isoformat(timespec='minutes')\n",
     "        continue\n",
     "    last_fetched = (\n",


### PR DESCRIPTION
## Summary
- update `update.ipynb` so that running it copies existing dated snapshots to the `latest` file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b8a998004832dad5df9704bcfce71