### PR TITLE
Add hourly schedule for update notebook

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -3,7 +3,8 @@ name: Update Data
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 2 * * *'
+    # Run every hour, five minutes after the hour
+    - cron: '5 * * * *'
 
 jobs:
   run-update:


### PR DESCRIPTION
## Summary
- run the `data/update.ipynb` notebook on a schedule every hour, five minutes after the hour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ba05d5250832d875f162805526a95