### PR TITLE
Automate data update merges

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -32,9 +32,13 @@ jobs:
           jupyter nbconvert --to notebook --execute data/update.ipynb --output update.ipynb --output-dir data
 
       - name: Create pull request
+        id: cpr
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: 'Automated data update'
           branch: data-refresh
           title: 'Automated data update'
           body: 'This PR contains results from running `data/update.ipynb`.'
+          delete-branch: true
+          merge: true
+          merge-method: squash

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ This repository drives [analysis.castromedia.org](https://analysis.castromedia.o
 
 1. **Aggregation** – The `data/` folder stores every raw dataset. A notebook called `update.ipynb` pulls from each source on a schedule, versioning the files and opening a pull request with the changes.
 2. **Analysis** – Jupyter notebooks inside `analysis/` use the latest data snapshots to produce figures and markdown reports. When data changes, these notebooks re-run automatically and propose another pull request.
-3. **Publication** – Once both pull requests are merged, GitHub Pages rebuilds the site using Jekyll. The rendered HTML lives in this repo so anyone can inspect the exact inputs and outputs.
+3. **Publication** – Once both pull requests are merged automatically (assuming no conflicts), GitHub Pages rebuilds the site using Jekyll. The rendered HTML lives in this repo so anyone can inspect the exact inputs and outputs.
 
 This setup aggregates data from many sources, analyzes it, and publishes the results in real time. Because every step happens in the open through Git commits and PRs, it offers a maximally transparent workflow for public research.


### PR DESCRIPTION
## Summary
- automatically merge the pull request opened by the scheduled data refresh job
- note auto-merging behavior in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d659eb798832d80221a03c06a0ea4