### PR TITLE
Add dashboard CSV export and index page

### DIFF
--- a/analysis/dashboard/dashboard.ipynb
+++ b/analysis/dashboard/dashboard.ipynb
@@ -63,6 +63,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from datetime import datetime\n",
+    "timestamp = datetime.utcnow().strftime('%Y-%m-%d-%H-00')\n",
+    "dashboard.to_csv(f'{timestamp}.csv', index=False)\n",
+    "dashboard.to_csv('latest.csv', index=False)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "print(f'Total headlines across feeds: {dashboard.headline_count.sum()}')\n"
    ]
   }

--- a/analysis/dashboard/index.md
+++ b/analysis/dashboard/index.md
@@ -1,0 +1,27 @@
+---
+layout: default
+title: Data Source Dashboard
+date: 2025-06-05
+---
+
+## Data Source Dashboard
+
+A summary of all data sources and their current headline counts.
+
+<div id="dashboard-table"></div>
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+  loadCsvTable('#dashboard-table', './latest.csv');
+});
+</script>
+
+## File Versions:
+{% assign csv_files = site.static_files | where:"extname", ".csv" | where_exp:"f","f.path contains 'analysis/dashboard/'" | sort: 'name' | reverse %}
+<ol>
+  <li><a href="./latest.csv">Latest version</a></li>
+  {% for file in csv_files %}
+    {% unless file.name == 'latest.csv' %}
+  <li><a href="./{{ file.name }}">{{ file.name }}</a></li>
+    {% endunless %}
+  {% endfor %}
+</ol>


### PR DESCRIPTION
## Summary
- update dashboard notebook to save a timestamped CSV and `latest.csv`
- add `analysis/dashboard/index.md` to display `latest.csv` in DataTables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876c425bd90832dbf2bab7acbdb6c42