### PR TITLE
Automate dashboard index regeneration

### DIFF
--- a/analysis/dashboard/dashboard.ipynb
+++ b/analysis/dashboard/dashboard.ipynb
@@ -120,7 +120,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>62 rows × 4 columns</p>\n",
+       "<p>62 rows \u00d7 4 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -232,6 +232,25 @@
    ],
    "source": [
     "print(f'Total headlines across feeds: {dashboard.headline_count.sum()}')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "write-index",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "from pathlib import Path\n",
+    "from string import Template\n",
+    "\n",
+    "timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')\n",
+    "\n",
+    "template_str = \"\"\"---\nlayout: default\ntitle: Data Source Dashboard\ndate: $date\n---\n\n## Data Source Dashboard\n\nA summary of all data sources and their current headline counts.\n\n<div id=\\\"dashboard-table\\\"></div>\n<script>\nfunction loadCsvTable(sel, csvPath){\n  fetch(csvPath)\n    .then(r => r.text())\n    .then(text => {\n      const rows = csvToObjects(text);\n      const table = ArrTabler(rows);\n      $(sel).html(table);\n      new DataTable(sel + ' table', {\n        order: [[0, 'desc']],\n        columnDefs: [\n          { targets: '_all', className: 'dt-head-left dt-body-left' }\n        ]\n      });\n    })\n    .catch(() => {\n      $(sel).text('Unable to load data.');\n    });\n}\n\ndocument.addEventListener('DOMContentLoaded', function(){\n  loadCsvTable('#dashboard-table', './latest.csv');\n});\n</script>\n\n## File Versions:\n{% assign csv_files = site.static_files | where:\"extname\", \".csv\" | where_exp:\"f\",\"f.path contains 'analysis/dashboard/'\" | sort: 'name' | reverse %}\n<ol>\n  <li><a href=\\\"./latest.csv\\\">Latest version</a></li>\n  {% for file in csv_files %}\n    {% unless file.name == 'latest.csv' %}\n  <li><a href=\\\"./{{ file.name }}\\\">{{ file.name }}</a></li>\n    {% endunless %}\n  {% endfor %}\n</ol>\n\"\"\"\n",
+    "\n",
+    "template = Template(template_str)\n",
+    "Path('index.md').write_text(template.safe_substitute(date=timestamp))\n"
    ]
   }
  ],

--- a/analysis/dashboard/index.md
+++ b/analysis/dashboard/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Data Source Dashboard
-date: 2025-06-05
+date: 2025-07-16 03:41:19
 ---
 
 ## Data Source Dashboard


### PR DESCRIPTION
## Summary
- add a code cell in `dashboard.ipynb` to write `index.md`
- regenerate the dashboard index with a timestamp

## Testing
- `python - <<'PY'
import json, ast; ast.parse(open('analysis/dashboard/dashboard.ipynb').read()); print('Compiled')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68771dc9aeac832da04adb1eb984e678