### PR TITLE
Add 24h headline count to dashboard

### DIFF
--- a/analysis/dashboard/dashboard.ipynb
+++ b/analysis/dashboard/dashboard.ipynb
@@ -128,7 +128,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>62 rows × 4 columns</p>\n",
+       "<p>62 rows \u00d7 4 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -182,6 +182,8 @@
     "from pathlib import Path\n",
     "import pandas as pd\n",
     "import json\n",
+    "from datetime import datetime, timezone, timedelta\n",
+    "from email.utils import parsedate_to_datetime\n",
     "\n",
     "catalog = pd.read_csv(Path('..','..','data','catalog.csv'))\n",
     "catalog['path'] = catalog.apply(lambda r: Path('..','..','data', r['category'], r['source'], r['folder']), axis=1)\n",
@@ -206,7 +208,35 @@
     "            return len(data['observations'])\n",
     "    return 0\n",
     "\n",
+    "def count_recent(row):\n",
+    "    ftype = str(row['filetype']).lower().strip()\n",
+    "    if ftype not in ('rss', 'xml'):\n",
+    "        return 0\n",
+    "    latest = row['path'] / 'latest.json'\n",
+    "    if not latest.exists():\n",
+    "        return 0\n",
+    "    with open(latest, encoding='utf-8') as f:\n",
+    "        data = json.load(f)\n",
+    "    entries = data.get('entries', []) if isinstance(data, dict) else data\n",
+    "    cutoff = datetime.now(timezone.utc) - timedelta(days=1)\n",
+    "    count = 0\n",
+    "    for item in entries:\n",
+    "        pub = item.get('published')\n",
+    "        if not pub:\n",
+    "            continue\n",
+    "        try:\n",
+    "            dt = parsedate_to_datetime(pub)\n",
+    "            if dt.tzinfo is None:\n",
+    "                dt = dt.replace(tzinfo=timezone.utc)\n",
+    "            dt = dt.astimezone(timezone.utc)\n",
+    "            if dt >= cutoff:\n",
+    "                count += 1\n",
+    "        except Exception:\n",
+    "            continue\n",
+    "    return count\n",
+    "\n",
     "dashboard['headline_count'] = dashboard.apply(count_headlines, axis=1)\n",
+    "dashboard['last_24h_count'] = dashboard.apply(count_recent, axis=1)\n",
     "dashboard = dashboard.sort_values('path').reset_index(drop=True)\n",
     "dashboard\n"
    ]
@@ -262,7 +292,8 @@
     }
    ],
    "source": [
-    "print(f'Total headlines across feeds: {dashboard.headline_count.sum()}')\n"
+    "print(f'Total headlines across feeds: {dashboard.headline_count.sum()}')\n",
+    "print(f'Headlines in last 24h: {dashboard.last_24h_count.sum()}')\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- update dashboard notebook with `last_24h_count` column
- print total count for headlines in the last 24 hours

## Testing
- `pip install pandas` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687796396efc832da7314e58f86f2827