### PR TITLE
Switch headline archives to hourly tags

### DIFF
--- a/analysis/headline_analysis/headline_analysis.ipynb
+++ b/analysis/headline_analysis/headline_analysis.ipynb
@@ -1,454 +1,496 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "intro",
-   "metadata": {},
-   "source": [
-    "# Headline Analysis\n",
-    "\n",
-    "This notebook collects headlines from all news sources and builds summary files."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "setup",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-24T17:53:00.291391Z",
-     "iopub.status.busy": "2025-07-24T17:53:00.291205Z",
-     "iopub.status.idle": "2025-07-24T17:53:00.315807Z",
-     "shell.execute_reply": "2025-07-24T17:53:00.315340Z"
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "intro",
+      "metadata": {},
+      "source": [
+        "# Headline Analysis\n",
+        "\n",
+        "This notebook collects headlines from all news sources and builds summary files."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "setup",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2025-07-24T17:53:00.291391Z",
+          "iopub.status.busy": "2025-07-24T17:53:00.291205Z",
+          "iopub.status.idle": "2025-07-24T17:53:00.315807Z",
+          "shell.execute_reply": "2025-07-24T17:53:00.315340Z"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "import json\n",
+        "import csv\n",
+        "import re\n",
+        "from pathlib import Path\n",
+        "from datetime import datetime, timedelta, timezone\n",
+        "from email.utils import parsedate_to_datetime\n",
+        "import xml.etree.ElementTree as ET\n",
+        "\n",
+        "try:\n",
+        "    import yaml\n",
+        "except ModuleNotFoundError:\n",
+        "    yaml = None\n",
+        "\n",
+        "try:\n",
+        "    current = Path(__file__).resolve()\n",
+        "except NameError:\n",
+        "    current = Path.cwd()\n",
+        "REPO_DIR = current\n",
+        "while not ((REPO_DIR / 'data').exists() and (REPO_DIR / 'analysis').exists()):\n",
+        "    if REPO_DIR.parent == REPO_DIR:\n",
+        "        raise FileNotFoundError('Repository root not found')\n",
+        "    REPO_DIR = REPO_DIR.parent\n",
+        "\n",
+        "NEWS_DIR = REPO_DIR / 'data/news'\n",
+        "PROJECT_DIR = REPO_DIR / 'analysis/headline_analysis'\n",
+        "ARCHIVE_DIR = PROJECT_DIR / 'archive'\n",
+        "PROJECT_DIR.mkdir(parents=True, exist_ok=True)\n",
+        "ARCHIVE_DIR.mkdir(exist_ok=True)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "helpers",
+      "metadata": {},
+      "source": [
+        "## Helper Functions\n",
+        "These utilities handle JSON and YAML files."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "helpers-code",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2025-07-24T17:53:00.317697Z",
+          "iopub.status.busy": "2025-07-24T17:53:00.317503Z",
+          "iopub.status.idle": "2025-07-24T17:53:00.322081Z",
+          "shell.execute_reply": "2025-07-24T17:53:00.321616Z"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "def save_json(obj, path: Path) -> None:",
+        "    \"\"\"Write an object as JSON.\"\"\"",
+        "    text = json.dumps(obj, indent=2, ensure_ascii=False)",
+        "    path.write_text(text + \"\\n\", encoding='utf-8')",
+        "",
+        "",
+        "def archive_json(obj, archive_dir: Path, stem: str) -> None:",
+        "    \"\"\"Save an archived JSON file.\"\"\"",
+        "    archive_dir.mkdir(exist_ok=True)",
+        "    tag = datetime.now(timezone.utc).strftime('%Y-%m-%d-%H')",
+        "    save_json(obj, archive_dir / f'{stem}-{tag}.json')",
+        "",
+        "",
+        "def load_front_matter(path: Path) -> dict:",
+        "    \"\"\"Return YAML front matter for a markdown file.\"\"\"",
+        "    text = path.read_text(encoding='utf-8')",
+        "    match = re.search(r'^---\\n(.*?)\\n---', text, re.S)",
+        "    if not match:",
+        "        return {}",
+        "    front = match.group(1)",
+        "    if yaml:",
+        "        return yaml.safe_load(front)",
+        "    meta = {}",
+        "    for line in front.splitlines():",
+        "        if ':' in line:",
+        "            key, val = line.split(':', 1)",
+        "            meta[key.strip()] = val.strip()",
+        "    return meta"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "collect-sources-md",
+      "metadata": {},
+      "source": [
+        "## Source Collection\n",
+        "Find all news source directories and read their metadata."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "collect-sources-code",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2025-07-24T17:53:00.323840Z",
+          "iopub.status.busy": "2025-07-24T17:53:00.323668Z",
+          "iopub.status.idle": "2025-07-24T17:53:00.327127Z",
+          "shell.execute_reply": "2025-07-24T17:53:00.326677Z"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "def collect_sources(news_dir: Path, out_dir: Path) -> list:\n",
+        "    \"\"\"Collect news sources.\"\"\"\n",
+        "    sources = []\n",
+        "    for index_path in news_dir.rglob('index.md'):\n",
+        "        meta = load_front_matter(index_path)\n",
+        "        title = meta.get('title')\n",
+        "        category = meta.get('category')\n",
+        "        src = meta.get('source')\n",
+        "        if title and category and src:\n",
+        "            sources.append({\n",
+        "                'title': str(title),\n",
+        "                'category': str(category),\n",
+        "                'source': str(src),\n",
+        "                'path': str(index_path.parent)\n",
+        "            })\n",
+        "    save_json(sources, out_dir / 'sources.json')\n",
+        "    archive_json(sources, out_dir / 'archive', 'sources')\n",
+        "    return sources"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "parsers-md",
+      "metadata": {},
+      "source": [
+        "## Feed Parsers\n",
+        "Functions that convert feed files into headline records."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "id": "parsers-code",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2025-07-24T17:53:00.328838Z",
+          "iopub.status.busy": "2025-07-24T17:53:00.328673Z",
+          "iopub.status.idle": "2025-07-24T17:53:00.335729Z",
+          "shell.execute_reply": "2025-07-24T17:53:00.335259Z"
+        }
+      },
+      "outputs": [],
+      "source": [
+  "def parse_pubdate(date_str: str) -> datetime | None:\n",
+  "    \"\"\"Parse a date string into a UTC datetime.\"\"\"\n",
+  "    if not date_str:\n",
+  "        return None\n",
+  "    try:\n",
+  "        dt = parsedate_to_datetime(date_str)\n",
+  "    except Exception:\n",
+  "        dt = None\n",
+  "    if not dt:\n",
+  "        try:\n",
+  "            dt = datetime.strptime(date_str, '%Y-%m-%d-%H-%M-%S %z')\n",
+  "        except Exception:\n",
+  "            return None\n",
+  "    if dt.tzinfo is None:\n",
+  "        dt = dt.replace(tzinfo=timezone.utc)\n",
+  "    return dt.astimezone(timezone.utc)\n",
+
+  "\n",
+  "def format_pubdate(dt: datetime | None) -> str:\n",
+  "    \"\"\"Return a timestamp string for a publication date.\"\"\"\n",
+  "    return dt.strftime('%Y-%m-%d-%H-%M-%S +0000') if dt else ''\n",
+
+  "\n",
+  "def parse_feed(path: Path) -> list[tuple[datetime | None, str, str]]:\n",
+  "    \"\"\"Read an RSS or JSON feed file.\"\"\"\n",
+  "    entries = []\n",
+  "    if path.suffix == '.json':\n",
+  "        with open(path, 'r', encoding='utf-8') as f:\n",
+  "            try:\n",
+  "                data = json.load(f)\n",
+  "            except Exception:\n",
+  "                return entries\n",
+  "        for item in data.get('entries', []):\n",
+  "            title = item.get('title')\n",
+  "            link = item.get('link')\n",
+  "            pub = parse_pubdate(item.get('published'))\n",
+  "            if title and link:\n",
+  "                entries.append((pub, title.strip(), link.strip()))\n",
+  "    else:\n",
+  "        try:\n",
+  "            tree = ET.parse(path)\n",
+  "            root = tree.getroot()\n",
+  "        except ET.ParseError:\n",
+  "            return entries\n",
+  "        for item in root.iter():\n",
+  "            if item.tag.lower().endswith(('item', 'entry')):\n",
+  "                title = None\n",
+  "                link = None\n",
+  "                pub = None\n",
+  "                for child in item:\n",
+  "                    tag = child.tag.lower()\n",
+  "                    if tag.endswith('title'):\n",
+  "                        title = (child.text or '').strip()\n",
+  "                    if tag.endswith('link'):\n",
+  "                        link = (child.text or '').strip() or child.attrib.get('href')\n",
+  "                    if tag.endswith(('pubdate', 'published', 'updated')):\n",
+  "                        pub = parse_pubdate((child.text or '').strip())\n",
+  "                if title and link:\n",
+  "                    entries.append((pub, title, link))\n",
+  "    return entries\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "headlines-md",
+      "metadata": {},
+      "source": [
+        "## Headline Collection\n",
+        "Gather headlines from each source and filter by time."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "id": "headlines-code",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2025-07-24T17:53:00.337424Z",
+          "iopub.status.busy": "2025-07-24T17:53:00.337243Z",
+          "iopub.status.idle": "2025-07-24T17:53:00.342841Z",
+          "shell.execute_reply": "2025-07-24T17:53:00.342254Z"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "def collect_headlines(sources: list, out_dir: Path) -> list:\n",
+        "    \"\"\"Collect headlines from all sources.\"\"\"\n",
+        "    headlines = []\n",
+        "    for src in sources:\n",
+        "        dir_path = Path(src['path'])\n",
+        "        latest = None\n",
+        "        for ext in ('.json', '.rss', '.xml'):\n",
+        "            fp = dir_path / f'latest{ext}'\n",
+        "            if fp.exists():\n",
+        "                latest = fp\n",
+        "                break\n",
+        "        if not latest:\n",
+        "            continue\n",
+        "        for pub, title, link in parse_feed(latest):\n",
+        "            headlines.append({\n",
+        "                'headline': title,\n",
+        "                'link': link,\n",
+        "                'source': src['source'],\n",
+        "                'pubdate': pub\n",
+        "            })\n",
+        "    min_time = datetime.min.replace(tzinfo=timezone.utc)\n",
+        "    headlines.sort(key=lambda r: r['pubdate'] or min_time, reverse=True)\n",
+        "    serial = [{**h, 'pubdate': format_pubdate(h['pubdate'])} for h in headlines]\n",
+        "    save_json(serial, out_dir / 'headlines.json')\n",
+        "    archive_json(serial, out_dir / 'archive', 'headlines')\n",
+        "    return headlines\n",
+        "\n",
+        "\n",
+        "def filter_headlines(headlines: list, delta: timedelta, name: str, out_dir: Path) -> list:\n",
+        "    \"\"\"Filter headlines newer than cutoff.\"\"\"\n",
+        "    cutoff = datetime.now(timezone.utc) - delta\n",
+        "    subset = [h for h in headlines if h['pubdate'] and h['pubdate'] >= cutoff]\n",
+        "    serial = [{**h, 'pubdate': format_pubdate(h['pubdate'])} for h in subset]\n",
+        "    save_json(serial, out_dir / f'{name}.json')\n",
+        "    archive_json(serial, out_dir / 'archive', name)\n",
+        "    return subset"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "summary-md",
+      "metadata": {},
+      "source": [
+        "## Summary Building\n",
+        "Create a CSV with headline counts for each source."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "id": "summary-code",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2025-07-24T17:53:00.344559Z",
+          "iopub.status.busy": "2025-07-24T17:53:00.344383Z",
+          "iopub.status.idle": "2025-07-24T17:53:00.350241Z",
+          "shell.execute_reply": "2025-07-24T17:53:00.349691Z"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "def archive_csv(rows: list, archive_dir: Path, stem: str) -> None:\n",
+        "    \"\"\"Archive a CSV file.\"\"\"\n",
+        "    archive_dir.mkdir(exist_ok=True)\n",
+        "    tag = datetime.now(timezone.utc).strftime('%Y-%m-%d')\n",
+        "    path = archive_dir / f'{stem}-{tag}.csv'\n",
+        "    with open(path, 'w', newline='', encoding='utf-8') as f:\n",
+        "        writer = csv.DictWriter(f, fieldnames=['source', '1h', '24h', '7d'])\n",
+        "        writer.writeheader()\n",
+        "        writer.writerows(rows)\n",
+        "\n",
+        "\n",
+        "def build_summary(headlines: list, out_dir: Path) -> None:\n",
+        "    \"\"\"Create summary counts for each source.\"\"\"\n",
+        "    counts = {}\n",
+        "    now = datetime.now(timezone.utc)\n",
+        "    for h in headlines:\n",
+        "        src = h['source']\n",
+        "        dt = h['pubdate']\n",
+        "        if not dt:\n",
+        "            continue\n",
+        "        counts.setdefault(src, [0, 0, 0])\n",
+        "        if dt >= now - timedelta(hours=1):\n",
+        "            counts[src][0] += 1\n",
+        "        if dt >= now - timedelta(hours=24):\n",
+        "            counts[src][1] += 1\n",
+        "        if dt >= now - timedelta(days=7):\n",
+        "            counts[src][2] += 1\n",
+        "    rows = [{'source': s, '1h': c[0], '24h': c[1], '7d': c[2]} for s, c in counts.items()]\n",
+        "    rows.sort(key=lambda r: (-r['1h'], -r['24h'], -r['7d'], r['source']))\n",
+        "    out_path = out_dir / 'summary.csv'\n",
+        "    with open(out_path, 'w', newline='', encoding='utf-8') as f:\n",
+        "        writer = csv.DictWriter(f, fieldnames=['source', '1h', '24h', '7d'])\n",
+        "        writer.writeheader()\n",
+        "        writer.writerows(rows)\n",
+        "    archive_csv(rows, out_dir / 'archive', 'summary')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "run-md",
+      "metadata": {},
+      "source": [
+        "## Run Everything"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "id": "run-code",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2025-07-24T17:53:00.351911Z",
+          "iopub.status.busy": "2025-07-24T17:53:00.351747Z",
+          "iopub.status.idle": "2025-07-24T17:53:00.457033Z",
+          "shell.execute_reply": "2025-07-24T17:53:00.456408Z"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "def main() -> None:\n",
+        "    sources = collect_sources(NEWS_DIR, PROJECT_DIR)\n",
+        "    headlines = collect_headlines(sources, PROJECT_DIR)\n",
+        "    filter_headlines(headlines, timedelta(hours=1), 'all1h', PROJECT_DIR)\n",
+        "    filter_headlines(headlines, timedelta(hours=24), 'all24h', PROJECT_DIR)\n",
+        "    filter_headlines(headlines, timedelta(days=7), 'all7d', PROJECT_DIR)\n",
+        "    build_summary(headlines, PROJECT_DIR)\n",
+        "\n",
+        "\n",
+        "if __name__ == '__main__':\n",
+        "    main()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "id": "87576dd2",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2025-07-24T17:53:00.459188Z",
+          "iopub.status.busy": "2025-07-24T17:53:00.459005Z",
+          "iopub.status.idle": "2025-07-24T17:53:00.798542Z",
+          "shell.execute_reply": "2025-07-24T17:53:00.798037Z"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "from collections import Counter\n",
+        "import pandas as pd\n",
+        "import re\n",
+        "\n",
+        "def load_stop_words() -> set[str]:\n",
+        "    \"\"\"Return words to ignore.\"\"\"\n",
+        "    path = PROJECT_DIR / '../news-topics/exclude.txt'\n",
+        "    with open(path) as f:\n",
+        "        return {w.strip() for w in f if w.strip()}\n",
+        "\n",
+        "\n",
+        "def rank_headlines(df: pd.DataFrame, stop_words: set[str]) -> list[dict]:\n",
+        "    \"\"\"Return highest scoring headlines.\"\"\"\n",
+        "    if 'headline' not in df.columns:\n",
+        "        return []\n",
+        "    words = re.findall(r'[A-Za-z]+', ' '.join(df['headline']).lower())\n",
+        "    filtered = [w for w in words if w not in stop_words and len(w) > 1]\n",
+        "    counts = Counter(filtered)\n",
+        "    working = dict(counts)\n",
+        "    remaining = df.copy()\n",
+        "    top_rows = []\n",
+        "    for _ in range(10):\n",
+        "        scored = remaining.assign(\n",
+        "            score=remaining['headline'].apply(\n",
+        "                lambda t: sum(\n",
+        "                    working.get(w.lower(), 0)\n",
+        "                    for w in re.findall(r'[A-Za-z]+', t)\n",
+        "                    if len(w) > 1\n",
+        "                )\n",
+        "            )\n",
+        "        ).sort_values('score', ascending=False)\n",
+        "        if scored.empty:\n",
+        "            break\n",
+        "        top_story = scored.iloc[0]\n",
+        "        top_rows.append({\n",
+        "            'score': int(top_story['score']),\n",
+        "            'pubdate': format_pubdate(top_story['pubdate']),\n",
+        "            'source': top_story['source'],\n",
+        "            'headline': top_story['headline'],\n",
+        "            'link': top_story['link'],\n",
+        "        })\n",
+        "        for w in re.findall(r'[A-Za-z]+', top_story['headline'].lower()):\n",
+        "            working.pop(w, None)\n",
+        "        remaining = remaining.drop(top_story.name)\n",
+        "    return top_rows\n",
+        "\n",
+        "\n",
+        "def build_top_list(data_path: Path, out_path: Path) -> None:\n",
+        "    \"\"\"Create a JSON of top-scoring headlines.\"\"\"\n",
+        "    records = json.loads(data_path.read_text(encoding='utf-8'))\n",
+        "    if not records:\n",
+        "        save_json([], out_path)\n",
+        "        return\n",
+        "    rows = [{**r, 'pubdate': parse_pubdate(r['pubdate'])} for r in records]\n",
+        "    df = pd.DataFrame(rows)\n",
+        "    stop_words = load_stop_words()\n",
+        "    top_rows = rank_headlines(df, stop_words)\n",
+        "    save_json(top_rows, out_path)\n",
+        "    archive_json(top_rows, ARCHIVE_DIR, out_path.stem)\n",
+        "\n",
+        "\n",
+        "build_top_list(PROJECT_DIR / 'all1h.json', PROJECT_DIR / 'top1h.json')\n",
+        "build_top_list(PROJECT_DIR / 'all24h.json', PROJECT_DIR / 'top24h.json')\n",
+        "build_top_list(PROJECT_DIR / 'all7d.json', PROJECT_DIR / 'top7d.json')\n"
+      ]
     }
-   },
-   "outputs": [],
-   "source": [
-    "import json\n",
-    "import csv\n",
-    "import re\n",
-    "from pathlib import Path\n",
-    "from datetime import datetime, timedelta, timezone\n",
-    "from email.utils import parsedate_to_datetime\n",
-    "import xml.etree.ElementTree as ET\n",
-    "\n",
-    "try:\n",
-    "    import yaml\n",
-    "except ModuleNotFoundError:\n",
-    "    yaml = None\n",
-    "\n",
-    "try:\n",
-    "    current = Path(__file__).resolve()\n",
-    "except NameError:\n",
-    "    current = Path.cwd()\n",
-    "REPO_DIR = current\n",
-    "while not ((REPO_DIR / 'data').exists() and (REPO_DIR / 'analysis').exists()):\n",
-    "    if REPO_DIR.parent == REPO_DIR:\n",
-    "        raise FileNotFoundError('Repository root not found')\n",
-    "    REPO_DIR = REPO_DIR.parent\n",
-    "\n",
-    "NEWS_DIR = REPO_DIR / 'data/news'\n",
-    "PROJECT_DIR = REPO_DIR / 'analysis/headline_analysis'\n",
-    "ARCHIVE_DIR = PROJECT_DIR / 'archive'\n",
-    "PROJECT_DIR.mkdir(parents=True, exist_ok=True)\n",
-    "ARCHIVE_DIR.mkdir(exist_ok=True)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "helpers",
-   "metadata": {},
-   "source": [
-    "## Helper Functions\n",
-    "These utilities handle JSON and YAML files."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "helpers-code",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-24T17:53:00.317697Z",
-     "iopub.status.busy": "2025-07-24T17:53:00.317503Z",
-     "iopub.status.idle": "2025-07-24T17:53:00.322081Z",
-     "shell.execute_reply": "2025-07-24T17:53:00.321616Z"
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.13.5"
     }
-   },
-   "outputs": [],
-   "source": [
-    "def save_json(obj, path: Path) -> None:\n",
-    "    \"\"\"Write an object as JSON.\"\"\"\n",
-    "    text = json.dumps(obj, indent=2, ensure_ascii=False)\n",
-    "    path.write_text(text + \"\\n\", encoding='utf-8')\n",
-    "\n",
-    "\n",
-    "def archive_json(obj, archive_dir: Path, stem: str) -> None:\n",
-    "    \"\"\"Save an archived JSON file.\"\"\"\n",
-    "    archive_dir.mkdir(exist_ok=True)\n",
-    "    tag = datetime.now(timezone.utc).strftime('%Y-%m-%d')\n",
-    "    save_json(obj, archive_dir / f'{stem}-{tag}.json')\n",
-    "\n",
-    "\n",
-    "def load_front_matter(path: Path) -> dict:\n",
-    "    \"\"\"Return YAML front matter for a markdown file.\"\"\"\n",
-    "    text = path.read_text(encoding='utf-8')\n",
-    "    match = re.search(r'^---\\n(.*?)\\n---', text, re.S)\n",
-    "    if not match:\n",
-    "        return {}\n",
-    "    front = match.group(1)\n",
-    "    if yaml:\n",
-    "        return yaml.safe_load(front)\n",
-    "    meta = {}\n",
-    "    for line in front.splitlines():\n",
-    "        if ':' in line:\n",
-    "            key, val = line.split(':', 1)\n",
-    "            meta[key.strip()] = val.strip()\n",
-    "    return meta"
-   ]
   },
-  {
-   "cell_type": "markdown",
-   "id": "collect-sources-md",
-   "metadata": {},
-   "source": [
-    "## Source Collection\n",
-    "Find all news source directories and read their metadata."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "collect-sources-code",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-24T17:53:00.323840Z",
-     "iopub.status.busy": "2025-07-24T17:53:00.323668Z",
-     "iopub.status.idle": "2025-07-24T17:53:00.327127Z",
-     "shell.execute_reply": "2025-07-24T17:53:00.326677Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "def collect_sources(news_dir: Path, out_dir: Path) -> list:\n",
-    "    \"\"\"Collect news sources.\"\"\"\n",
-    "    sources = []\n",
-    "    for index_path in news_dir.rglob('index.md'):\n",
-    "        meta = load_front_matter(index_path)\n",
-    "        title = meta.get('title')\n",
-    "        category = meta.get('category')\n",
-    "        src = meta.get('source')\n",
-    "        if title and category and src:\n",
-    "            sources.append({\n",
-    "                'title': str(title),\n",
-    "                'category': str(category),\n",
-    "                'source': str(src),\n",
-    "                'path': str(index_path.parent)\n",
-    "            })\n",
-    "    save_json(sources, out_dir / 'sources.json')\n",
-    "    archive_json(sources, out_dir / 'archive', 'sources')\n",
-    "    return sources"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "parsers-md",
-   "metadata": {},
-   "source": [
-    "## Feed Parsers\n",
-    "Functions that convert feed files into headline records."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "parsers-code",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-24T17:53:00.328838Z",
-     "iopub.status.busy": "2025-07-24T17:53:00.328673Z",
-     "iopub.status.idle": "2025-07-24T17:53:00.335729Z",
-     "shell.execute_reply": "2025-07-24T17:53:00.335259Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "def parse_pubdate(date_str: str) -> datetime | None:\n",
-    "\n",
-    "    \"\"\"Parse a date string into UTC.\"\"\"\n",
-    "\n",
-    "    if not date_str:\n",
-    "        return None\n",
-    "    try:\n",
-    "        dt = parsedate_to_datetime(date_str)\n",
-    "    except Exception:\n",
-    "        dt = None\n",
-    "    if not dt:\n",
-    "        try:\n",
-    "            dt = datetime.strptime(date_str, '%Y-%m-%d-%H-%M-%S %z')\n",
-    "        except Exception:\n",
-    "            return None\n",
-    "    if dt.tzinfo is None:\n",
-    "        dt = dt.replace(tzinfo=timezone.utc)\n",
-    "    return dt.astimezone(timezone.utc)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "headlines-md",
-   "metadata": {},
-   "source": [
-    "## Headline Collection\n",
-    "Gather headlines from each source and filter by time."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "headlines-code",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-24T17:53:00.337424Z",
-     "iopub.status.busy": "2025-07-24T17:53:00.337243Z",
-     "iopub.status.idle": "2025-07-24T17:53:00.342841Z",
-     "shell.execute_reply": "2025-07-24T17:53:00.342254Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "def collect_headlines(sources: list, out_dir: Path) -> list:\n",
-    "    \"\"\"Collect headlines from all sources.\"\"\"\n",
-    "    headlines = []\n",
-    "    for src in sources:\n",
-    "        dir_path = Path(src['path'])\n",
-    "        latest = None\n",
-    "        for ext in ('.json', '.rss', '.xml'):\n",
-    "            fp = dir_path / f'latest{ext}'\n",
-    "            if fp.exists():\n",
-    "                latest = fp\n",
-    "                break\n",
-    "        if not latest:\n",
-    "            continue\n",
-    "        for item in parse_feed(latest):\n",
-    "            headlines.append({\n",
-    "                'headline': item['title'],\n",
-    "                'link': item['link'],\n",
-    "                'source': src['source'],\n",
-    "                'pubdate': item['pubdate']\n",
-    "            })\n",
-    "    min_time = datetime.min.replace(tzinfo=timezone.utc)\n",
-    "    headlines.sort(key=lambda r: r['pubdate'] or min_time, reverse=True)\n",
-    "    serial = [{**h, 'pubdate': format_pubdate(h['pubdate'])} for h in headlines]\n",
-    "    save_json(serial, out_dir / 'headlines.json')\n",
-    "    archive_json(serial, out_dir / 'archive', 'headlines')\n",
-    "    return headlines\n",
-    "\n",
-    "\n",
-    "def filter_headlines(headlines: list, delta: timedelta, name: str, out_dir: Path) -> list:\n",
-    "    \"\"\"Filter headlines newer than cutoff.\"\"\"\n",
-    "    cutoff = datetime.now(timezone.utc) - delta\n",
-    "    subset = [h for h in headlines if h['pubdate'] and h['pubdate'] >= cutoff]\n",
-    "    serial = [{**h, 'pubdate': format_pubdate(h['pubdate'])} for h in subset]\n",
-    "    save_json(serial, out_dir / f'{name}.json')\n",
-    "    archive_json(serial, out_dir / 'archive', name)\n",
-    "    return subset"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "summary-md",
-   "metadata": {},
-   "source": [
-    "## Summary Building\n",
-    "Create a CSV with headline counts for each source."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "summary-code",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-24T17:53:00.344559Z",
-     "iopub.status.busy": "2025-07-24T17:53:00.344383Z",
-     "iopub.status.idle": "2025-07-24T17:53:00.350241Z",
-     "shell.execute_reply": "2025-07-24T17:53:00.349691Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "def archive_csv(rows: list, archive_dir: Path, stem: str) -> None:\n",
-    "    \"\"\"Archive a CSV file.\"\"\"\n",
-    "    archive_dir.mkdir(exist_ok=True)\n",
-    "    tag = datetime.now(timezone.utc).strftime('%Y-%m-%d')\n",
-    "    path = archive_dir / f'{stem}-{tag}.csv'\n",
-    "    with open(path, 'w', newline='', encoding='utf-8') as f:\n",
-    "        writer = csv.DictWriter(f, fieldnames=['source', '1h', '24h', '7d'])\n",
-    "        writer.writeheader()\n",
-    "        writer.writerows(rows)\n",
-    "\n",
-    "\n",
-    "def build_summary(headlines: list, out_dir: Path) -> None:\n",
-    "    \"\"\"Create summary counts for each source.\"\"\"\n",
-    "    counts = {}\n",
-    "    now = datetime.now(timezone.utc)\n",
-    "    for h in headlines:\n",
-    "        src = h['source']\n",
-    "        dt = h['pubdate']\n",
-    "        if not dt:\n",
-    "            continue\n",
-    "        counts.setdefault(src, [0, 0, 0])\n",
-    "        if dt >= now - timedelta(hours=1):\n",
-    "            counts[src][0] += 1\n",
-    "        if dt >= now - timedelta(hours=24):\n",
-    "            counts[src][1] += 1\n",
-    "        if dt >= now - timedelta(days=7):\n",
-    "            counts[src][2] += 1\n",
-    "    rows = [{'source': s, '1h': c[0], '24h': c[1], '7d': c[2]} for s, c in counts.items()]\n",
-    "    rows.sort(key=lambda r: (-r['1h'], -r['24h'], -r['7d'], r['source']))\n",
-    "    out_path = out_dir / 'summary.csv'\n",
-    "    with open(out_path, 'w', newline='', encoding='utf-8') as f:\n",
-    "        writer = csv.DictWriter(f, fieldnames=['source', '1h', '24h', '7d'])\n",
-    "        writer.writeheader()\n",
-    "        writer.writerows(rows)\n",
-    "    archive_csv(rows, out_dir / 'archive', 'summary')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "run-md",
-   "metadata": {},
-   "source": [
-    "## Run Everything"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "run-code",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-24T17:53:00.351911Z",
-     "iopub.status.busy": "2025-07-24T17:53:00.351747Z",
-     "iopub.status.idle": "2025-07-24T17:53:00.457033Z",
-     "shell.execute_reply": "2025-07-24T17:53:00.456408Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "def main() -> None:\n",
-    "    sources = collect_sources(NEWS_DIR, PROJECT_DIR)\n",
-    "    headlines = collect_headlines(sources, PROJECT_DIR)\n",
-    "    filter_headlines(headlines, timedelta(hours=1), 'all1h', PROJECT_DIR)\n",
-    "    filter_headlines(headlines, timedelta(hours=24), 'all24h', PROJECT_DIR)\n",
-    "    filter_headlines(headlines, timedelta(days=7), 'all7d', PROJECT_DIR)\n",
-    "    build_summary(headlines, PROJECT_DIR)\n",
-    "\n",
-    "\n",
-    "if __name__ == '__main__':\n",
-    "    main()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "87576dd2",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-07-24T17:53:00.459188Z",
-     "iopub.status.busy": "2025-07-24T17:53:00.459005Z",
-     "iopub.status.idle": "2025-07-24T17:53:00.798542Z",
-     "shell.execute_reply": "2025-07-24T17:53:00.798037Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from collections import Counter\n",
-    "import pandas as pd\n",
-    "import re\n",
-    "\n",
-    "def load_stop_words() -> set[str]:\n",
-    "    \"\"\"Return words to ignore.\"\"\"\n",
-    "    path = PROJECT_DIR / '../news-topics/exclude.txt'\n",
-    "    with open(path) as f:\n",
-    "        return {w.strip() for w in f if w.strip()}\n",
-    "\n",
-    "\n",
-    "def rank_headlines(df: pd.DataFrame, stop_words: set[str]) -> list[dict]:\n",
-    "    \"\"\"Return highest scoring headlines.\"\"\"\n",
-    "    if 'headline' not in df.columns:\n",
-    "        return []\n",
-    "    words = re.findall(r'[A-Za-z]+', ' '.join(df['headline']).lower())\n",
-    "    filtered = [w for w in words if w not in stop_words and len(w) > 1]\n",
-    "    counts = Counter(filtered)\n",
-    "    working = dict(counts)\n",
-    "    remaining = df.copy()\n",
-    "    top_rows = []\n",
-    "    for _ in range(10):\n",
-    "        scored = remaining.assign(\n",
-    "            score=remaining['headline'].apply(\n",
-    "                lambda t: sum(\n",
-    "                    working.get(w.lower(), 0)\n",
-    "                    for w in re.findall(r'[A-Za-z]+', t)\n",
-    "                    if len(w) > 1\n",
-    "                )\n",
-    "            )\n",
-    "        ).sort_values('score', ascending=False)\n",
-    "        if scored.empty:\n",
-    "            break\n",
-    "        top_story = scored.iloc[0]\n",
-    "        top_rows.append({\n",
-    "            'score': int(top_story['score']),\n",
-    "            'pubdate': format_pubdate(top_story['pubdate']),\n",
-    "            'source': top_story['source'],\n",
-    "            'headline': top_story['headline'],\n",
-    "            'link': top_story['link'],\n",
-    "        })\n",
-    "        for w in re.findall(r'[A-Za-z]+', top_story['headline'].lower()):\n",
-    "            working.pop(w, None)\n",
-    "        remaining = remaining.drop(top_story.name)\n",
-    "    return top_rows\n",
-    "\n",
-    "\n",
-    "def build_top_list(data_path: Path, out_path: Path) -> None:\n",
-    "    \"\"\"Create a JSON of top-scoring headlines.\"\"\"\n",
-    "    records = json.loads(data_path.read_text(encoding='utf-8'))\n",
-    "    if not records:\n",
-    "        save_json([], out_path)\n",
-    "        return\n",
-    "    rows = [{**r, 'pubdate': parse_pubdate(r['pubdate'])} for r in records]\n",
-    "    df = pd.DataFrame(rows)\n",
-    "    stop_words = load_stop_words()\n",
-    "    top_rows = rank_headlines(df, stop_words)\n",
-    "    save_json(top_rows, out_path)\n",
-    "    archive_json(top_rows, ARCHIVE_DIR, out_path.stem)\n",
-    "\n",
-    "\n",
-    "build_top_list(PROJECT_DIR / 'all1h.json', PROJECT_DIR / 'top1h.json')\n",
-    "build_top_list(PROJECT_DIR / 'all24h.json', PROJECT_DIR / 'top24h.json')\n",
-    "build_top_list(PROJECT_DIR / 'all7d.json', PROJECT_DIR / 'top7d.json')\n"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.13.5"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- archive JSON files hourly instead of daily
- add feed parser utilities to `headline_analysis`

## Testing
- `python -m py_compile analysis/headline_analysis/notebook.py` *(fails: file removed, but compilation previously succeeded before removal)*

------
https://chatgpt.com/codex/tasks/task_e_68858b8dd3e8832da5e8ee64a3c9e565