### PR TITLE
Add descriptions to compute and dashboard analysis pages

### DIFF
--- a/analysis/compute/index.md
+++ b/analysis/compute/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Compute
+description: Catalogues estimated int8 compute accessible to different actors.
 ---
 
 # Compute

--- a/analysis/dashboard/index.md
+++ b/analysis/dashboard/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Data Source Dashboard
+description: Summarizes all data sources and their current headline counts.
 date: 2025-07-18 22:34:03
 ---
 


### PR DESCRIPTION
## Summary
- add missing description for compute project
- add missing description for data source dashboard

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68995ca1d3c8832d85e4d9ebe577dbcc