### PR TITLE
Use log scale for compute chart x axis

### DIFF
--- a/analysis/compute/compute.ipynb
+++ b/analysis/compute/compute.ipynb
@@ -44,7 +44,7 @@
    "source": [
     "## Collect front matter and build `data.csv`\n",
     "\n",
-    "The Markdown files in the `entities` directory store metadata about each actor in a YAML front\u2011matter block. This code walks through every `.md` file in that directory, extracts the `name`, `compute` (renamed to `ops`), and `stakeholder` (renamed to `stakeholders`) fields, converts them to numeric types, and writes them out to a CSV file called `data.csv`. This CSV will be used for plotting in the next step."
+    "The Markdown files in the `entities` directory store metadata about each actor in a YAML front‑matter block. This code walks through every `.md` file in that directory, extracts the `name`, `compute` (renamed to `ops`), and `stakeholder` (renamed to `stakeholders`) fields, converts them to numeric types, and writes them out to a CSV file called `data.csv`. This CSV will be used for plotting in the next step."
    ]
   },
   {
@@ -120,7 +120,7 @@
     "                ops_value = float(compute)\n",
     "            except ValueError:\n",
     "                # Try to convert with replacements\n",
-    "                tmp = str(compute).lower().replace('\u00d7', 'e').replace('^', '')\n",
+    "                tmp = str(compute).lower().replace('×', 'e').replace('^', '')\n",
     "                tmp = tmp.replace('int8', '')\n",
     "                try:\n",
     "                    ops_value = float(tmp)\n",
@@ -157,7 +157,7 @@
    "source": [
     "## Plot compute versus stakeholders\n",
     "\n",
-    "This final step reads the data, colors each point by its category, and draws a key to explain the colors. The horizontal axis shows the number of stakeholders on a linear scale, while the vertical axis shows the estimated int8 operations per second on a logarithmic scale. Labels are spaced on the right side of the chart with connector lines, and the legend is anchored outside the plot so it never overlaps the data.\n"
+    "This final step reads the data, colors each point by its category, and draws a key to explain the colors. Both axes use logarithmic scales: the horizontal axis for stakeholder counts and the vertical axis for estimated int8 operations per second. Labels are spaced on the right side of the chart with connector lines, and the legend is anchored outside the plot so it never overlaps the data.\n"
    ]
   },
   {
@@ -1573,11 +1573,11 @@
     "# Set up axes\n",
     "ax.set_xlabel('Number of stakeholders')\n",
     "ax.set_ylabel('Estimated int8 ops per second')\n",
+    "ax.set_xscale('log')\n",
     "ax.set_yscale('log')\n",
-    "ax.set_xlim(\n",
-    "    min_stakeholder - (max_stakeholder - min_stakeholder) * 0.05,\n",
-    "    max_stakeholder + (max_stakeholder - min_stakeholder) * 0.3,\n",
-    ")\n",
+    "x_min = min_stakeholder * 0.9\n",
+    "x_max = max_stakeholder * 1.3\n",
+    "ax.set_xlim(x_min, x_max)\n",
     "ax.set_ylim(min_ops * 0.9, max_ops * 1.1)\n",
     "\n",
     "# Assign colors to each category\n",
@@ -1615,10 +1615,11 @@
     "    y_positions = [min_ops]\n",
     "\n",
     "# Place labels on the right side of the figure\n",
-    "label_x = max_stakeholder + (max_stakeholder - min_stakeholder) * 0.15\n",
+    "label_x = max_stakeholder * 1.15\n",
+    "label_anchor = label_x * 0.98\n",
     "for point, label_y in zip(sorted_points, y_positions):\n",
     "    ax.plot(\n",
-    "        [point['stakeholders'], label_x * 0.98],\n",
+    "        [point['stakeholders'], label_anchor],\n",
     "        [point['ops'], label_y],\n",
     "        color='gray',\n",
     "        linewidth=0.5,\n",


### PR DESCRIPTION
## Summary
- switch compute plot's x axis to logarithmic scale
- adjust axis bounds and label placement for log x axis
- clarify documentation that both axes use log scales

## Testing
- `pytest`
- `python -c "import matplotlib"` *(fails: No module named 'matplotlib')*
- `python -m pip install matplotlib` *(fails: Could not find a version that satisfies the requirement matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_6899668c9e4c832db5a631f22f186b34