### PR TITLE
Add Alphabet compute entry

### DIFF
--- a/analysis/compute/data.csv
+++ b/analysis/compute/data.csv
@@ -8,3 +8,4 @@ Meta,institutions,1e+19,15
 Microsoft,institutions,4e+20,15
 United States Federal Government,empires,5e+18,600
 University of California,academia,4e+18,300
+Alphabet,institutions,1e+20,15

--- a/analysis/compute/entities/alphabet.md
+++ b/analysis/compute/entities/alphabet.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Alphabet
+name: Alphabet
+category: institutions
+compute: 1e20
+stakeholder: 15
+---
+
+Alphabet runs large TPU and GPU clusters that support Google services and research at scale. Public disclosures around TPU v4 and v5 pods suggest that, aggregated across thousands of chips, Alphabet controls on the order of 10^20 dense INT8 operations per second.[^1]
+
+Roughly fifteen senior executives and board members ultimately direct how this infrastructure is used.
+
+[^1]: See "Inside Google's TPUv4 Pods," Google Cloud Blog, 2021, and "Google Plans AI Supercomputer With TPU v5p" reports in 2023.

--- a/analysis/compute/index.md
+++ b/analysis/compute/index.md
@@ -10,6 +10,7 @@ This project catalogues estimated int8 compute accessible to different actors. Y
 
 The chart compares relative compute power of different classes of entities, versus stakeholder counts:
 
+- [Alphabet](./entities/alphabet.md)
 - [Amazon](./entities/amazon.md)
 - [Apple](./entities/apple.md)
 - [California State University](./entities/california-state-university.md)


### PR DESCRIPTION
## Summary
- add Alphabet compute entity with TPU/GPU capacity and governance details
- record Alphabet compute and stakeholder counts in compute dataset
- link Alphabet page from compute index

## Testing
- `python - <<'PY'` (chart generation) *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- `pip install matplotlib` *(fails: Could not find a version that satisfies the requirement matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_68996f873594832d87964f4e31d74ffe