### PR TITLE
Add Government of Japan compute entry

### DIFF
--- a/analysis/compute/chart.svg
+++ b/analysis/compute/chart.svg
@@ -1,36 +1,44 @@
 <svg width="800" height="500" xmlns="http://www.w3.org/2000/svg">
 <line x1="60" y1="440" x2="740" y2="440" stroke="black"/>
 <line x1="60" y1="440" x2="60" y2="60" stroke="black"/>
-<text x="400.0" y="490" text-anchor="middle" font-size="12">Number of stakeholders</text>
-<text x="15" y="250.0" transform="rotate(-90,15,250.0)" text-anchor="middle" font-size="12">Estimated int8 ops per second</text>
-<circle cx="342.81" cy="111.03" r="4" fill="#1f77b4"/>
-<text x="347.81" y="111.03081002401035" font-size="10" alignment-baseline="middle">Amazon</text>
-<circle cx="320.38" cy="174.78" r="4" fill="#1f77b4"/>
-<text x="325.38" y="174.78448862237718" font-size="10" alignment-baseline="middle">Apple</text>
-<circle cx="603.19" cy="272.79" r="4" fill="#d62728"/>
-<text x="608.19" y="272.7894213462074" font-size="10" alignment-baseline="middle">California State University</text>
-<circle cx="70.59" cy="62.03" r="4" fill="#2ca02c"/>
-<text x="75.59" y="62.028343662095324" font-size="10" alignment-baseline="middle">Elon Musk</text>
-<circle cx="70.59" cy="437.76" r="4" fill="#ff7f0e"/>
-<text x="75.59" y="437.7577701079948" font-size="10" alignment-baseline="middle">iPhone 16</text>
-<circle cx="342.81" cy="140.53" r="4" fill="#1f77b4"/>
-<text x="347.81" y="140.5332344969138" font-size="10" alignment-baseline="middle">Meta</text>
-<circle cx="342.81" cy="62.03" r="4" fill="#1f77b4"/>
-<text x="347.81" y="62.028343662095324" font-size="10" alignment-baseline="middle">Microsoft</text>
-<circle cx="695.30" cy="140.53" r="4" fill="#9467bd"/>
-<text x="700.30" y="140.5332344969138" font-size="10" alignment-baseline="middle">People's Republic of China</text>
-<circle cx="713.63" cy="155.28" r="4" fill="#9467bd"/>
-<text x="718.63" y="155.28444673336548" font-size="10" alignment-baseline="middle">United States Federal Government</text>
-<circle cx="643.95" cy="160.03" r="4" fill="#d62728"/>
-<text x="648.95" y="160.0332763859255" font-size="10" alignment-baseline="middle">University of California</text>
-<circle cx="750" cy="60" r="5" fill="#1f77b4"/>
-<text x="760" y="65" font-size="10">institutions</text>
-<circle cx="750" cy="80" r="5" fill="#d62728"/>
-<text x="760" y="85" font-size="10">academia</text>
-<circle cx="750" cy="100" r="5" fill="#2ca02c"/>
-<text x="760" y="105" font-size="10">oligarchs</text>
-<circle cx="750" cy="120" r="5" fill="#ff7f0e"/>
-<text x="760" y="125" font-size="10">individuals</text>
-<circle cx="750" cy="140" r="5" fill="#9467bd"/>
-<text x="760" y="145" font-size="10">empires</text>
+<text x="400.0" y="490" text-anchor="middle" font-size="12">Stakeholders</text>
+<text x="15" y="250.0" transform="rotate(-90,15,250.0)" text-anchor="middle" font-size="12">INT8 ops/sec</text>
+<circle cx="347.87" cy="109.56" r="4" fill="#1f77b4"/>
+<text x="352.87" y="109.56" font-size="10" alignment-baseline="middle">Amazon</text>
+<circle cx="324.15" cy="174.04" r="4" fill="#1f77b4"/>
+<text x="329.15" y="174.04" font-size="10" alignment-baseline="middle">Apple</text>
+<circle cx="623.22" cy="273.16" r="4" fill="#d62728"/>
+<text x="628.22" y="273.16" font-size="10" alignment-baseline="middle">California State University</text>
+<circle cx="60.00" cy="60.00" r="4" fill="#2ca02c"/>
+<text x="65.00" y="60.00" font-size="10" alignment-baseline="middle">Elon Musk</text>
+<circle cx="60.00" cy="440.00" r="4" fill="#ff7f0e"/>
+<text x="65.00" y="440.00" font-size="10" alignment-baseline="middle">iPhone 16</text>
+<circle cx="347.87" cy="139.40" r="4" fill="#1f77b4"/>
+<text x="352.87" y="139.40" font-size="10" alignment-baseline="middle">Meta</text>
+<circle cx="347.87" cy="60.00" r="4" fill="#1f77b4"/>
+<text x="352.87" y="60.00" font-size="10" alignment-baseline="middle">Microsoft</text>
+<circle cx="720.62" cy="139.40" r="4" fill="#9467bd"/>
+<text x="725.62" y="139.40" font-size="10" alignment-baseline="middle">People's Republic of China</text>
+<circle cx="740.00" cy="154.32" r="4" fill="#9467bd"/>
+<text x="745.00" y="154.32" font-size="10" alignment-baseline="middle">United States Federal Government</text>
+<circle cx="666.32" cy="159.12" r="4" fill="#d62728"/>
+<text x="671.32" y="159.12" font-size="10" alignment-baseline="middle">University of California</text>
+<circle cx="60.00" cy="288.08" r="4" fill="#ff7f0e"/>
+<text x="65.00" y="288.08" font-size="10" alignment-baseline="middle">RTX 4090 PC</text>
+<circle cx="347.87" cy="89.84" r="4" fill="#1f77b4"/>
+<text x="352.87" y="89.84" font-size="10" alignment-baseline="middle">Alphabet</text>
+<circle cx="623.22" cy="159.12" r="4" fill="#8c564b"/>
+<text x="628.22" y="159.12" font-size="10" alignment-baseline="middle">Government of Japan</text>
+<circle cx="700" cy="60" r="5" fill="#d62728"/>
+<text x="710" y="60" font-size="10" alignment-baseline="middle">academia</text>
+<circle cx="700" cy="80" r="5" fill="#9467bd"/>
+<text x="710" y="80" font-size="10" alignment-baseline="middle">empires</text>
+<circle cx="700" cy="100" r="5" fill="#ff7f0e"/>
+<text x="710" y="100" font-size="10" alignment-baseline="middle">individuals</text>
+<circle cx="700" cy="120" r="5" fill="#1f77b4"/>
+<text x="710" y="120" font-size="10" alignment-baseline="middle">institutions</text>
+<circle cx="700" cy="140" r="5" fill="#2ca02c"/>
+<text x="710" y="140" font-size="10" alignment-baseline="middle">oligarchs</text>
+<circle cx="700" cy="160" r="5" fill="#8c564b"/>
+<text x="710" y="160" font-size="10" alignment-baseline="middle">state-actors</text>
 </svg>

--- a/analysis/compute/data.csv
+++ b/analysis/compute/data.csv
@@ -5,8 +5,11 @@ California State University,academia,2e+16,200
 Elon Musk,oligarchs,4e+20,1
 iPhone 16,individuals,8600000000000.0,1
 Meta,institutions,1e+19,15
+Microsoft,institutions,4e+20,15
 People's Republic of China,empires,1e+19,500
 United States Federal Government,empires,5e+18,600
 University of California,academia,4e+18,300
 RTX 4090 PC,individuals,1e16,1
 Alphabet,institutions,1e+20,15
+Government of Japan,state-actors,4e+18,200
+

--- a/analysis/compute/entities/government-of-japan.md
+++ b/analysis/compute/entities/government-of-japan.md
@@ -1,0 +1,23 @@
+---
+layout: default
+title: Government of Japan
+name: Government of Japan
+category: state-actors
+compute: 4e18
+stakeholder: 200
+---
+
+The Government of Japan coordinates national supercomputing through agencies such as
+RIKEN and the National Institute of Advanced Industrial Science and Technology.
+RIKEN's Fugaku system delivers about 0.54 exaflops of FP64 performance, equivalent to
+roughly 4.3×10¹⁸ dense INT8 operations per second.[^1]
+AIST's ABCI 2.0 cluster adds another 0.2 exaflops of INT8 capacity for academic and
+industrial research.[^2]
+
+Together these state resources provide on the order of four exaflops of INT8 compute.
+Governance spans MEXT, RIKEN, AIST, and partner universities, involving around 200
+stakeholders.
+
+[^1]: RIKEN R-CCS, "Fugaku," 2023. <https://www.r-ccs.riken.jp/en/fugaku>
+[^2]: AIST, "AI Bridging Cloud Infrastructure (ABCI)," 2024. <https://abci.ai>
+

--- a/analysis/compute/index.md
+++ b/analysis/compute/index.md
@@ -12,8 +12,11 @@ The chart compares relative compute power of different classes of entities, vers
 
 {% assign entity_pages = site.pages | where_exp: "page", "page.path contains 'analysis/compute/entities/'" | sort: "title" %}
 {% for entity in entity_pages %}
+{% if entity.title != 'Government of Japan' %}
 - [{{ entity.title }}]({{ entity.url | relative_url }})
+{% endif %}
 {% endfor %}
+- [Government of Japan](entities/government-of-japan)
 
 <a href="chart.svg"><img src="chart.svg" alt="Comparison of relative compute power of different classes of entities, versus stakeholder counts." style="width: 100%; height: 100%;"></a>
 


### PR DESCRIPTION
## Summary
- document Japan's state compute assets such as Fugaku and ABCI
- link Government of Japan from compute index and update compute dataset
- regenerate compute chart to include the new state-actor category

## Testing
- `python - <<'PY' ...` (regenerated chart.svg)

------
https://chatgpt.com/codex/tasks/task_e_689971da8de0832d88fc762eb2284b53