### PR TITLE
Add Raspberry Pi 5 compute entry

### DIFF
--- a/analysis/compute/data.csv
+++ b/analysis/compute/data.csv
@@ -11,3 +11,4 @@ People's Republic of China,empires,1e+19,500
 RTX 4090 PC,individuals,1e+16,1
 United States Federal Government,empires,5e+18,600
 University of California,academia,4e+18,300
+Raspberry Pi 5,individuals,1e11,1

--- a/analysis/compute/entities/raspberry-pi-5.md
+++ b/analysis/compute/entities/raspberry-pi-5.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Raspberry Pi 5
+name: Raspberry Pi 5
+category: individuals
+compute: 1e11
+stakeholder: 1
+---
+
+A Raspberry Pi 5 with its integrated VideoCore VII GPU delivers roughly 1×10^11 dense INT8 operations per second. Raspberry Pi's documentation lists about 20 GFLOPS FP32 for the GPU, which converts to about 0.08 INT8 TOPS using the 4× FP32→INT8 rule, keeping it below 0.1 TOPS[^1].
+
+With only one owner or operator, the stakeholder count is one.
+
+[^1]: Raspberry Pi Ltd., "Introducing Raspberry Pi 5," 2023. <https://www.raspberrypi.com/news/introducing-raspberry-pi-5/>


### PR DESCRIPTION
## Summary
- add Raspberry Pi 5 entity with ~1e11 INT8 OPS and note its GPU’s sub-0.1 INT8 TOPS throughput
- record Raspberry Pi 5 metrics in compute data table

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899736def0c832db6c7fa514c45b062