### PR TITLE
Add Coral USB Accelerator compute data

### DIFF
--- a/analysis/compute/data.csv
+++ b/analysis/compute/data.csv
@@ -11,3 +11,4 @@ People's Republic of China,empires,1e+19,500
 RTX 4090 PC,individuals,1e+16,1
 United States Federal Government,empires,5e+18,600
 University of California,academia,4e+18,300
+Coral USB Accelerator,individuals,4e12,1

--- a/analysis/compute/entities/coral-usb-accelerator.md
+++ b/analysis/compute/entities/coral-usb-accelerator.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Coral USB Accelerator
+name: Coral USB Accelerator
+category: individuals
+compute: 4e12
+stakeholder: 1
+---
+
+The Coral USB Accelerator is a USB module featuring an Edge TPU coprocessor that delivers 4 INT8 TOPS for on‑device machine learning inference.[^1]
+
+With a single device per user, the stakeholder count is one.
+
+[^1]: Google, "USB Accelerator," Coral. <https://coral.ai/products/usb-accelerator>


### PR DESCRIPTION
## Summary
- add entity page for Coral USB Accelerator citing its 4 INT8 TOPS capability
- record Coral USB Accelerator in compute data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899736ed27c832dbf64722a4c68f886