### PR TITLE
Add Larry Ellison entity

### DIFF
--- a/analysis/compute/entities/larry-ellison.md
+++ b/analysis/compute/entities/larry-ellison.md
@@ -1,0 +1,35 @@
+---
+layout: default
+title: Larry Ellison
+name: Larry Ellison
+category: oligarch
+compute: 5e19
+stakeholders: 1
+---
+
+## Description
+Larry Ellison co-founded Oracle and serves as executive chairman.
+He directs Oracle's plan for a supercomputer using about 26,000
+NVIDIA H100 GPUs, enabling roughly 5×10^19 dense INT8 operations
+per second.[^1][^2]
+
+## Scope
+- Oracle announced plans for a supercomputer using about
+  26,000 NVIDIA H100 GPUs, yielding roughly 5×10^19 dense INT8
+  operations per second.[^1][^2]
+- Oracle operates additional data centers, but accessible compute
+  figures are limited.
+
+Total compute: 5×10^19 dense INT8 operations per second.
+
+## Implications
+Ellison's control over Oracle's cloud resources positions him to
+shape enterprise AI development. Concentrating these capabilities in
+a single stakeholder raises questions about oversight, yet it also
+enables rapid experimentation and services for Oracle's customers.
+
+## Works cited
+[^1]: Oracle. "Oracle and NVIDIA collaborate on AI infrastructure." 2023.
+<https://www.oracle.com/news/announcement/oracle-nvidia-ai-infrastructure-2023/>
+[^2]: Colfax. "NVIDIA H100 Tensor Core GPU." 2023.
+<https://colfaxresearch.com/nvidia-h100-performance/>


### PR DESCRIPTION
## Summary
- estimate Oracle's 26,000 H100 GPU plan at ~5e19 INT8 OPS for Larry Ellison
- drop unsupported PDF reference from works cited

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a38ad2ba4832da0e4fd51de085b17