### PR TITLE
Standardize compute field notation

### DIFF
--- a/analysis/compute/entities/alphabet.md
+++ b/analysis/compute/entities/alphabet.md
@@ -3,7 +3,7 @@ layout: default
 title: Alphabet
 name: Alphabet
 category: corporation
-compute: 2e19
+compute: 2e+19
 stakeholders: 15
 ---
 

--- a/analysis/compute/entities/apple.md
+++ b/analysis/compute/entities/apple.md
@@ -3,7 +3,7 @@ layout: default
 title: Apple
 name: Apple
 category: corporation
-compute: 5e19
+compute: 5e+19
 stakeholders: 12
 ---
 

--- a/analysis/compute/entities/california-state-university.md
+++ b/analysis/compute/entities/california-state-university.md
@@ -3,7 +3,7 @@ layout: default
 title: California State University
 name: California State University
 category: academia
-compute: 5e16
+compute: 5e+16
 stakeholders: 200
 ---
 

--- a/analysis/compute/entities/coral-usb-accelerator.md
+++ b/analysis/compute/entities/coral-usb-accelerator.md
@@ -3,7 +3,7 @@ layout: default
 title: Coral USB Accelerator
 name: Coral USB Accelerator
 category: individuals
-compute: 4e12
+compute: 4e+12
 stakeholders: 1
 ---
 

--- a/analysis/compute/entities/elon-musk.md
+++ b/analysis/compute/entities/elon-musk.md
@@ -3,7 +3,7 @@ layout: default
 title: Elon Musk
 name: Elon Musk
 category: oligarch
-compute: 2e20
+compute: 2e+20
 stakeholders: 1
 ---
 

--- a/analysis/compute/entities/eth-zurich.md
+++ b/analysis/compute/entities/eth-zurich.md
@@ -3,7 +3,7 @@ layout: default
 title: ETH Zürich
 name: ETH Zürich
 category: academia
-compute: 2e17
+compute: 2e+17
 stakeholders: 70
 ---
 

--- a/analysis/compute/entities/european-union.md
+++ b/analysis/compute/entities/european-union.md
@@ -3,7 +3,7 @@ layout: default
 title: European Union
 name: European Union
 category: state actor
-compute: 1.4e19
+compute: 1.4e+19
 stakeholders: 100
 ---
 

--- a/analysis/compute/entities/government-of-india.md
+++ b/analysis/compute/entities/government-of-india.md
@@ -3,7 +3,7 @@ layout: default
 title: Government of India
 name: Government of India
 category: state actor
-compute: 1e16
+compute: 1e+16
 stakeholders: 100
 ---
 

--- a/analysis/compute/entities/government-of-japan.md
+++ b/analysis/compute/entities/government-of-japan.md
@@ -3,7 +3,7 @@ layout: default
 title: Government of Japan
 name: Government of Japan
 category: state actor
-compute: 4e18
+compute: 4e+18
 stakeholders: 200
 ---
 

--- a/analysis/compute/entities/indian-institute-of-science.md
+++ b/analysis/compute/entities/indian-institute-of-science.md
@@ -3,7 +3,7 @@ layout: default
 title: Indian Institute of Science
 name: Indian Institute of Science
 category: academia
-compute: 3e16
+compute: 3e+16
 stakeholders: 50
 ---
 

--- a/analysis/compute/entities/iphone-16.md
+++ b/analysis/compute/entities/iphone-16.md
@@ -3,7 +3,7 @@ layout: default
 title: iPhone 16
 name: iPhone 16
 category: individuals
-compute: 8.6e12
+compute: 8.6e+12
 stakeholders: 1
 ---
 

--- a/analysis/compute/entities/jetson-orin-nx.md
+++ b/analysis/compute/entities/jetson-orin-nx.md
@@ -3,7 +3,7 @@ layout: default
 title: Jetson Orin NX
 name: Jetson Orin NX
 category: individuals
-compute: 1e14
+compute: 1e+14
 stakeholders: 1
 ---
 

--- a/analysis/compute/entities/larry-ellison.md
+++ b/analysis/compute/entities/larry-ellison.md
@@ -3,7 +3,7 @@ layout: default
 title: Larry Ellison
 name: Larry Ellison
 category: oligarch
-compute: 5e19
+compute: 5e+19
 stakeholders: 1
 ---
 

--- a/analysis/compute/entities/macbook-m3.md
+++ b/analysis/compute/entities/macbook-m3.md
@@ -3,7 +3,7 @@ layout: default
 title: MacBook M3
 name: MacBook M3
 category: individuals
-compute: 1.8e13
+compute: 1.8e+13
 stakeholders: 1
 ---
 

--- a/analysis/compute/entities/meta.md
+++ b/analysis/compute/entities/meta.md
@@ -3,7 +3,7 @@ layout: default
 title: Meta
 name: Meta
 category: corporation
-compute: 1e19
+compute: 1e+19
 stakeholders: 15
 ---
 

--- a/analysis/compute/entities/microsoft.md
+++ b/analysis/compute/entities/microsoft.md
@@ -3,7 +3,7 @@ layout: default
 title: Microsoft
 name: Microsoft
 category: corporation
-compute: 2e19
+compute: 2e+19
 stakeholders: 15
 ---
 

--- a/analysis/compute/entities/moscow-state-university.md
+++ b/analysis/compute/entities/moscow-state-university.md
@@ -3,7 +3,7 @@ layout: default
 title: Moscow State University
 name: Moscow State University
 category: academia
-compute: 2e17
+compute: 2e+17
 stakeholders: 70
 ---
 

--- a/analysis/compute/entities/national-university-of-singapore.md
+++ b/analysis/compute/entities/national-university-of-singapore.md
@@ -3,7 +3,7 @@ layout: default
 title: National University of Singapore
 name: National University of Singapore
 category: academia
-compute: 8e16
+compute: 8e+16
 stakeholders: 60
 ---
 

--- a/analysis/compute/entities/peking-university.md
+++ b/analysis/compute/entities/peking-university.md
@@ -3,7 +3,7 @@ layout: default
 title: Peking University
 name: Peking University
 category: academia
-compute: 1e17
+compute: 1e+17
 stakeholders: 60
 ---
 

--- a/analysis/compute/entities/peoples-republic-of-china.md
+++ b/analysis/compute/entities/peoples-republic-of-china.md
@@ -3,7 +3,7 @@ layout: default
 title: People's Republic of China
 name: People's Republic of China
 category: state actor
-compute: 1e19
+compute: 1e+19
 stakeholders: 500
 ---
 

--- a/analysis/compute/entities/playstation-5.md
+++ b/analysis/compute/entities/playstation-5.md
@@ -3,7 +3,7 @@ layout: default
 title: PlayStation 5
 name: PlayStation 5
 category: individuals
-compute: 4.1e13
+compute: 4.1e+13
 stakeholders: 1
 ---
 

--- a/analysis/compute/entities/rtx-4090.md
+++ b/analysis/compute/entities/rtx-4090.md
@@ -3,7 +3,7 @@ layout: default
 title: RTX 4090 PC
 name: RTX 4090 PC
 category: individuals
-compute: 1.3e15
+compute: 1.3e+15
 stakeholders: 1
 ---
 

--- a/analysis/compute/entities/russian-federation.md
+++ b/analysis/compute/entities/russian-federation.md
@@ -3,7 +3,7 @@ layout: default
 title: Russian Federation
 name: Russian Federation
 category: state actor
-compute: 2e17
+compute: 2e+17
 stakeholders: 250
 ---
 

--- a/analysis/compute/entities/seoul-national-university.md
+++ b/analysis/compute/entities/seoul-national-university.md
@@ -3,7 +3,7 @@ layout: default
 title: Seoul National University
 name: Seoul National University
 category: academia
-compute: 5e16
+compute: 5e+16
 stakeholders: 40
 ---
 

--- a/analysis/compute/entities/stanford-university.md
+++ b/analysis/compute/entities/stanford-university.md
@@ -3,7 +3,7 @@ layout: default
 title: Stanford University
 name: Stanford University
 category: academia
-compute: 1e18
+compute: 1e+18
 stakeholders: 200
 ---
 

--- a/analysis/compute/entities/tsinghua-university.md
+++ b/analysis/compute/entities/tsinghua-university.md
@@ -3,7 +3,7 @@ layout: default
 title: Tsinghua University
 name: Tsinghua University
 category: academia
-compute: 1e18
+compute: 1e+18
 stakeholders: 80
 ---
 

--- a/analysis/compute/entities/united-kingdom-government.md
+++ b/analysis/compute/entities/united-kingdom-government.md
@@ -3,7 +3,7 @@ layout: default
 title: United Kingdom Government
 name: United Kingdom Government
 category: state actor
-compute: 2e17
+compute: 2e+17
 stakeholders: 100
 ---
 

--- a/analysis/compute/entities/united-states-federal-government.md
+++ b/analysis/compute/entities/united-states-federal-government.md
@@ -3,7 +3,7 @@ layout: default
 title: United States Federal Government
 name: United States Federal Government
 category: empire
-compute: 5e19
+compute: 5e+19
 stakeholders: 600
 ---
 

--- a/analysis/compute/entities/university-of-california.md
+++ b/analysis/compute/entities/university-of-california.md
@@ -3,7 +3,7 @@ layout: default
 title: University of California
 name: University of California
 category: academia
-compute: 4e18
+compute: 4e+18
 stakeholders: 300
 ---
 

--- a/analysis/compute/entities/university-of-cambridge.md
+++ b/analysis/compute/entities/university-of-cambridge.md
@@ -3,7 +3,7 @@ layout: default
 title: University of Cambridge
 name: University of Cambridge
 category: academia
-compute: 5e16
+compute: 5e+16
 stakeholders: 60
 ---
 

--- a/analysis/compute/entities/university-of-florida.md
+++ b/analysis/compute/entities/university-of-florida.md
@@ -3,7 +3,7 @@ layout: default
 title: University of Florida
 name: University of Florida
 category: academia
-compute: 7e17
+compute: 7e+17
 stakeholders: 50
 ---
 

--- a/analysis/compute/entities/university-of-michigan.md
+++ b/analysis/compute/entities/university-of-michigan.md
@@ -3,7 +3,7 @@ layout: default
 title: University of Michigan
 name: University of Michigan
 category: academia
-compute: 6e16
+compute: 6e+16
 stakeholders: 80
 ---
 

--- a/analysis/compute/entities/university-of-oxford.md
+++ b/analysis/compute/entities/university-of-oxford.md
@@ -3,7 +3,7 @@ layout: default
 title: University of Oxford
 name: University of Oxford
 category: academia
-compute: 8e15
+compute: 8e+15
 stakeholders: 50
 ---
 

--- a/analysis/compute/entities/university-of-texas-at-austin.md
+++ b/analysis/compute/entities/university-of-texas-at-austin.md
@@ -3,7 +3,7 @@ layout: default
 title: University of Texas at Austin
 name: University of Texas at Austin
 category: academia
-compute: 3e17
+compute: 3e+17
 stakeholders: 100
 ---
 

--- a/analysis/compute/entities/university-of-tokyo.md
+++ b/analysis/compute/entities/university-of-tokyo.md
@@ -3,7 +3,7 @@ layout: default
 title: University of Tokyo
 name: University of Tokyo
 category: academia
-compute: 1e17
+compute: 1e+17
 stakeholders: 60
 ---
 

--- a/analysis/compute/entities/university-of-wisconsin-madison.md
+++ b/analysis/compute/entities/university-of-wisconsin-madison.md
@@ -3,7 +3,7 @@ layout: default
 title: University of Wisconsin–Madison
 name: University of Wisconsin–Madison
 category: academia
-compute: 6e16
+compute: 6e+16
 stakeholders: 70
 ---
 

--- a/analysis/compute/entities/xbox-series-x.md
+++ b/analysis/compute/entities/xbox-series-x.md
@@ -3,7 +3,7 @@ layout: default
 title: Xbox Series X
 name: Xbox Series X
 category: individuals
-compute: 4.8e13
+compute: 4.8e+13
 stakeholders: 1
 ---
 


### PR DESCRIPTION
## Summary
- Ensure all entity `compute` fields use explicit `e+` scientific notation for dense INT8 TOPS values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a3f264074832d887c77703cda21a8