### PR TITLE
Add San Francisco news RSS feeds

### DIFF
--- a/analysis/headline_analysis/sources.json
+++ b/analysis/headline_analysis/sources.json
@@ -240,6 +240,24 @@
     "path": "/home/runner/work/Analysis/Analysis/data/news/us/wsj/news-us-wsj"
   },
   {
+    "title": "48hills - News from 48 Hills",
+    "category": "news-us",
+    "source": "48hills",
+    "path": "/home/runner/work/Analysis/Analysis/data/news/us/48hills/news-us-48hills"
+  },
+  {
+    "title": "eltecolote - News from El Tecolote",
+    "category": "news-us",
+    "source": "eltecolote",
+    "path": "/home/runner/work/Analysis/Analysis/data/news/us/eltecolote/news-us-eltecolote"
+  },
+  {
+    "title": "missionlocal - News from Mission Local",
+    "category": "news-us",
+    "source": "missionlocal",
+    "path": "/home/runner/work/Analysis/Analysis/data/news/us/missionlocal/news-us-missionlocal"
+  },
+  {
     "title": "dw - Top News from Deutsche Welle",
     "category": "news-top",
     "source": "dw",

--- a/data/news/us/48hills/news-us-48hills/index.md
+++ b/data/news/us/48hills/news-us-48hills/index.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: 48hills - News from 48 Hills
+date: 2025-08-14T07:32
+category: news-us
+source: 48hills
+filetype: rss
+folder: news-us-48hills
+url: https://48hills.org/feed/
+api_key: null
+cadence: hourly
+last_fetched: null
+description: News from 48 Hills
+link: https://48hills.org
+---
+
+## 48hills - News from 48 Hills
+
+<div id="data-chart"></div>
+<div id="data-table"></div>
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+  document.getElementById('data-table').textContent = 'This source isn't supported for tables yet.';
+});
+</script>
+
+## File Versions:
+1. [Latest version](./latest.rss)

--- a/data/news/us/eltecolote/news-us-eltecolote/index.md
+++ b/data/news/us/eltecolote/news-us-eltecolote/index.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: eltecolote - News from El Tecolote
+date: 2025-08-14T07:32
+category: news-us
+source: eltecolote
+filetype: rss
+folder: news-us-eltecolote
+url: https://eltecolote.org/content/en/feed/
+api_key: null
+cadence: hourly
+last_fetched: null
+description: News from El Tecolote
+link: https://eltecolote.org
+---
+
+## eltecolote - News from El Tecolote
+
+<div id="data-chart"></div>
+<div id="data-table"></div>
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+  document.getElementById('data-table').textContent = 'This source isn't supported for tables yet.';
+});
+</script>
+
+## File Versions:
+1. [Latest version](./latest.rss)

--- a/data/news/us/missionlocal/news-us-missionlocal/index.md
+++ b/data/news/us/missionlocal/news-us-missionlocal/index.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: missionlocal - News from Mission Local
+date: 2025-08-14T07:32
+category: news-us
+source: missionlocal
+filetype: rss
+folder: news-us-missionlocal
+url: https://missionlocal.org/feed/
+api_key: null
+cadence: hourly
+last_fetched: null
+description: News from Mission Local
+link: https://missionlocal.org
+---
+
+## missionlocal - News from Mission Local
+
+<div id="data-chart"></div>
+<div id="data-table"></div>
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+  document.getElementById('data-table').textContent = 'This source isn't supported for tables yet.';
+});
+</script>
+
+## File Versions:
+1. [Latest version](./latest.rss)


### PR DESCRIPTION
## Summary
- register San Francisco news sources 48hills, El Tecolote, and Mission Local
- remove placeholder `latest.rss` snapshot files to allow real data to populate later

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d90449100832db05786274a226ef5